### PR TITLE
#108: [6.3] Implement Cache Status Headers

### DIFF
--- a/src/handlers/stargazers.ts
+++ b/src/handlers/stargazers.ts
@@ -14,6 +14,9 @@ import { createRedisClient } from '../services/redis';
 import { checkGitHubRateLimit } from '../services/github-ratelimit';
 import { getStargazersFromCache, cacheStargazers } from '../services/cache';
 import { triggerBackgroundRefresh } from '../services/cache-refresh';
+import { shouldBypassCache } from '../utils/cache';
+import { createCacheHeaders } from '../utils/headers';
+import type { CacheHeaderInfo } from '../types/cache';
 
 export async function handleStargazers(
   request: Request,
@@ -54,9 +57,10 @@ export async function handleStargazers(
   }
 
   const redis = createRedisClient(env);
+  const bypassCache = shouldBypassCache(request);
 
-  // Check cache first for fast responses
-  if (redis) {
+  // Check cache first for fast responses (unless bypass requested)
+  if (redis && !bypassCache) {
     try {
       const cacheResult = await getStargazersFromCache(
         redis,
@@ -67,10 +71,14 @@ export async function handleStargazers(
       );
 
       if (cacheResult.hit && cacheResult.data) {
+        const cacheInfo: CacheHeaderInfo = {
+          status: 'HIT',
+          age: cacheResult.age,
+        };
+        const cacheHeaders = createCacheHeaders(cacheInfo);
         const headers = new Headers();
-        headers.set('X-Cache', 'HIT');
-        if (cacheResult.age !== undefined) {
-          headers.set('X-Cache-Age', String(cacheResult.age));
+        for (const [key, value] of Object.entries(cacheHeaders)) {
+          headers.set(key, value);
         }
         if (cacheResult.isStale) {
           headers.set('X-Cache-Stale', 'true');
@@ -111,6 +119,19 @@ export async function handleStargazers(
         }),
       );
     }
+  }
+
+  if (bypassCache) {
+    console.log(
+      JSON.stringify({
+        level: 'info',
+        message: 'Cache bypass requested via Cache-Control header',
+        owner,
+        repo: repoName,
+        page: pagination.page,
+        perPage: pagination.perPage,
+      }),
+    );
   }
 
   // Check GitHub rate limit before making API calls

--- a/src/types/cache.ts
+++ b/src/types/cache.ts
@@ -1,5 +1,12 @@
 import type { StargazerListResponse } from './stargazers';
 
+export type CacheStatus = 'HIT' | 'MISS';
+
+export interface CacheHeaderInfo {
+  status: CacheStatus;
+  age?: number;
+}
+
 export interface CachedStargazerData {
   data: StargazerListResponse;
   cachedAt: number;

--- a/src/utils/cache.test.ts
+++ b/src/utils/cache.test.ts
@@ -6,6 +6,7 @@ import {
   isStale,
   shouldProactiveRefresh,
   getCacheAge,
+  shouldBypassCache,
 } from './cache';
 
 describe('buildStargazerCacheKey', () => {
@@ -142,5 +143,54 @@ describe('getCacheAge', () => {
     vi.spyOn(Date, 'now').mockReturnValue(now * 1000);
     const cachedAt = now - 3600;
     expect(getCacheAge(cachedAt)).toBe(3600);
+  });
+});
+
+describe('shouldBypassCache', () => {
+  it('returns true for no-cache directive', () => {
+    const request = new Request('http://test.com', {
+      headers: { 'Cache-Control': 'no-cache' },
+    });
+    expect(shouldBypassCache(request)).toBe(true);
+  });
+
+  it('returns true for no-store directive', () => {
+    const request = new Request('http://test.com', {
+      headers: { 'Cache-Control': 'no-store' },
+    });
+    expect(shouldBypassCache(request)).toBe(true);
+  });
+
+  it('returns true for no-cache among multiple directives', () => {
+    const request = new Request('http://test.com', {
+      headers: { 'Cache-Control': 'max-age=0, no-cache' },
+    });
+    expect(shouldBypassCache(request)).toBe(true);
+  });
+
+  it('returns false for max-age=0', () => {
+    const request = new Request('http://test.com', {
+      headers: { 'Cache-Control': 'max-age=0' },
+    });
+    expect(shouldBypassCache(request)).toBe(false);
+  });
+
+  it('returns false when no Cache-Control header', () => {
+    const request = new Request('http://test.com');
+    expect(shouldBypassCache(request)).toBe(false);
+  });
+
+  it('handles case-insensitive directives', () => {
+    const request = new Request('http://test.com', {
+      headers: { 'Cache-Control': 'No-Cache' },
+    });
+    expect(shouldBypassCache(request)).toBe(true);
+  });
+
+  it('returns false for empty Cache-Control header', () => {
+    const request = new Request('http://test.com', {
+      headers: { 'Cache-Control': '' },
+    });
+    expect(shouldBypassCache(request)).toBe(false);
   });
 });

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -48,3 +48,13 @@ export function shouldProactiveRefresh(
 export function getCacheAge(cachedAt: number): number {
   return Math.floor(Date.now() / 1000) - cachedAt;
 }
+
+export function shouldBypassCache(request: Request): boolean {
+  const cacheControl = request.headers.get('Cache-Control');
+  if (!cacheControl) {
+    return false;
+  }
+
+  const directives = cacheControl.toLowerCase().split(',').map((d) => d.trim());
+  return directives.includes('no-cache') || directives.includes('no-store');
+}

--- a/src/utils/headers.test.ts
+++ b/src/utils/headers.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { createRateLimitHeaders, createRateLimitedHeaders, withRateLimitHeaders } from './headers';
+import {
+  createRateLimitHeaders,
+  createRateLimitedHeaders,
+  withRateLimitHeaders,
+  createCacheHeaders,
+  withCacheHeaders,
+  withApiHeaders,
+} from './headers';
 import type { RateLimitInfo } from '../types/ratelimit';
 
 describe('createRateLimitHeaders', () => {
@@ -97,5 +104,109 @@ describe('withRateLimitHeaders', () => {
     const original = new Response('ok', { status: 200 });
     const result = withRateLimitHeaders(original, info);
     expect(result.headers.get('Retry-After')).toBeNull();
+  });
+});
+
+describe('createCacheHeaders', () => {
+  it('returns X-Cache: HIT with age for cache hit', () => {
+    const headers = createCacheHeaders({ status: 'HIT', age: 3600 });
+    expect(headers['X-Cache']).toBe('HIT');
+    expect(headers['X-Cache-Age']).toBe('3600');
+  });
+
+  it('returns X-Cache: MISS without age for cache miss', () => {
+    const headers = createCacheHeaders({ status: 'MISS' });
+    expect(headers['X-Cache']).toBe('MISS');
+    expect(headers['X-Cache-Age']).toBeUndefined();
+  });
+
+  it('floors age to integer', () => {
+    const headers = createCacheHeaders({ status: 'HIT', age: 3600.7 });
+    expect(headers['X-Cache-Age']).toBe('3600');
+  });
+
+  it('does not include age when status is MISS even if age is provided', () => {
+    const headers = createCacheHeaders({ status: 'MISS', age: 100 });
+    expect(headers['X-Cache-Age']).toBeUndefined();
+  });
+
+  it('includes age of 0 for HIT', () => {
+    const headers = createCacheHeaders({ status: 'HIT', age: 0 });
+    expect(headers['X-Cache-Age']).toBe('0');
+  });
+
+  it('does not include negative age', () => {
+    const headers = createCacheHeaders({ status: 'HIT', age: -5 });
+    expect(headers['X-Cache-Age']).toBeUndefined();
+  });
+});
+
+describe('withCacheHeaders', () => {
+  it('adds cache headers to response', () => {
+    const original = new Response('{"ok":true}', {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const result = withCacheHeaders(original, { status: 'HIT', age: 120 });
+    expect(result.headers.get('X-Cache')).toBe('HIT');
+    expect(result.headers.get('X-Cache-Age')).toBe('120');
+    expect(result.headers.get('Content-Type')).toBe('application/json');
+  });
+
+  it('preserves original response status', () => {
+    const original = new Response('ok', { status: 201 });
+    const result = withCacheHeaders(original, { status: 'MISS' });
+    expect(result.status).toBe(201);
+  });
+
+  it('preserves original response body', async () => {
+    const body = JSON.stringify({ data: 'test' });
+    const original = new Response(body, { status: 200 });
+    const result = withCacheHeaders(original, { status: 'MISS' });
+    expect(await result.text()).toBe(body);
+  });
+});
+
+describe('withApiHeaders', () => {
+  const rateLimitInfo: RateLimitInfo = { remaining: 42, limit: 100, resetAt: 1710864000 };
+
+  it('applies both rate limit and cache headers', () => {
+    const original = new Response('ok', { status: 200 });
+    const result = withApiHeaders(original, {
+      rateLimit: rateLimitInfo,
+      cache: { status: 'HIT', age: 60 },
+    });
+
+    expect(result.headers.get('X-RateLimit-Limit')).toBe('100');
+    expect(result.headers.get('X-RateLimit-Remaining')).toBe('42');
+    expect(result.headers.get('X-Cache')).toBe('HIT');
+    expect(result.headers.get('X-Cache-Age')).toBe('60');
+  });
+
+  it('applies only cache headers when no rate limit info', () => {
+    const original = new Response('ok', { status: 200 });
+    const result = withApiHeaders(original, {
+      cache: { status: 'MISS' },
+    });
+
+    expect(result.headers.get('X-Cache')).toBe('MISS');
+    expect(result.headers.get('X-RateLimit-Limit')).toBeNull();
+  });
+
+  it('applies only rate limit headers when no cache info', () => {
+    const original = new Response('ok', { status: 200 });
+    const result = withApiHeaders(original, {
+      rateLimit: rateLimitInfo,
+    });
+
+    expect(result.headers.get('X-RateLimit-Limit')).toBe('100');
+    expect(result.headers.get('X-Cache')).toBeNull();
+  });
+
+  it('returns original response when no options provided', async () => {
+    const original = new Response('ok', { status: 200 });
+    const result = withApiHeaders(original, {});
+    expect(await result.text()).toBe('ok');
   });
 });

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -1,4 +1,5 @@
 import type { RateLimitInfo } from '../types/ratelimit';
+import type { CacheHeaderInfo } from '../types/cache';
 
 export function createRateLimitHeaders(info: RateLimitInfo): Record<string, string> {
   if (info.remaining < 0) {
@@ -38,4 +39,50 @@ export function withRateLimitHeaders(response: Response, info: RateLimitInfo): R
     statusText: response.statusText,
     headers: newHeaders,
   });
+}
+
+export function createCacheHeaders(info: CacheHeaderInfo): Record<string, string> {
+  const headers: Record<string, string> = {
+    'X-Cache': info.status,
+  };
+
+  if (info.status === 'HIT' && info.age !== undefined && info.age >= 0) {
+    headers['X-Cache-Age'] = Math.floor(info.age).toString();
+  }
+
+  return headers;
+}
+
+export function withCacheHeaders(response: Response, info: CacheHeaderInfo): Response {
+  const headers = createCacheHeaders(info);
+  const newHeaders = new Headers(response.headers);
+  for (const [key, value] of Object.entries(headers)) {
+    newHeaders.set(key, value);
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: newHeaders,
+  });
+}
+
+export function withApiHeaders(
+  response: Response,
+  options: {
+    rateLimit?: RateLimitInfo;
+    cache?: CacheHeaderInfo;
+  },
+): Response {
+  let result = response;
+
+  if (options.rateLimit) {
+    result = withRateLimitHeaders(result, options.rateLimit);
+  }
+
+  if (options.cache) {
+    result = withCacheHeaders(result, options.cache);
+  }
+
+  return result;
 }


### PR DESCRIPTION
## Summary

- Added `CacheStatus` (`HIT` | `MISS`) and `CacheHeaderInfo` types to `src/types/cache.ts`
- Added `createCacheHeaders()`, `withCacheHeaders()`, and `withApiHeaders()` utilities to `src/utils/headers.ts`
- Added `shouldBypassCache()` to `src/utils/cache.ts` — parses `Cache-Control: no-cache` / `no-store` to skip cache reads
- Updated stargazers handler to use utility functions for cache headers and support forced cache bypass via `Cache-Control` header
- Added 20 new tests covering cache header generation, bypass logic, and combined API headers

## Test plan

- [x] Unit tests for `createCacheHeaders` (HIT with age, MISS without age, floors age, handles edge cases)
- [x] Unit tests for `withCacheHeaders` (preserves status, body, existing headers)
- [x] Unit tests for `withApiHeaders` (combines rate limit + cache headers without conflicts)
- [x] Unit tests for `shouldBypassCache` (no-cache, no-store, max-age=0 ignored, case-insensitive, no header)
- [x] All 179 tests pass, typecheck and lint clean

Closes #108