### PR TITLE
#109: [7.1] Implement Standardized Error Responses

### DIFF
--- a/src/handlers/keys.ts
+++ b/src/handlers/keys.ts
@@ -1,7 +1,7 @@
 import { createDatabase } from '../db';
 import { createApiKey } from '../services/apiKeys';
 import { rotateApiKey, revokeApiKey } from '../services/key-rotation';
-import { createErrorResponse } from '../types/errors';
+import { ApiError, Errors } from '../types/errors';
 import type { Env } from '../types';
 import type { AuthContext } from '../types/auth';
 import type { CreateKeyResponse } from '../types/apiKeys';
@@ -20,7 +20,7 @@ export async function handleCreateKey(
 
   try {
     if (!env.DATABASE_URL) {
-      return createErrorResponse('INTERNAL_ERROR', 'An unexpected error occurred', 500);
+      throw Errors.internal();
     }
 
     const db = createDatabase(env.DATABASE_URL);
@@ -41,8 +41,11 @@ export async function handleCreateKey(
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
     console.error('Create key error:', error);
-    return createErrorResponse('INTERNAL_ERROR', 'An unexpected error occurred', 500);
+    throw Errors.internal();
   }
 }
 
@@ -53,7 +56,7 @@ export async function handleKeyRotation(
 ): Promise<Response> {
   try {
     if (!env.DATABASE_URL) {
-      return createErrorResponse('INTERNAL_ERROR', 'An unexpected error occurred', 500);
+      throw Errors.internal();
     }
 
     const db = createDatabase(env.DATABASE_URL);
@@ -61,9 +64,9 @@ export async function handleKeyRotation(
 
     if (!result.success) {
       if (result.error === 'NO_EXISTING_KEY') {
-        return createErrorResponse('KEY_NOT_FOUND', 'No active API key found to rotate', 400);
+        throw Errors.keyNotFound();
       }
-      return createErrorResponse('INTERNAL_ERROR', 'An unexpected error occurred', 500);
+      throw Errors.internal();
     }
 
     return new Response(
@@ -80,8 +83,11 @@ export async function handleKeyRotation(
       },
     );
   } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
     console.error('Key rotation error:', error);
-    return createErrorResponse('INTERNAL_ERROR', 'An unexpected error occurred', 500);
+    throw Errors.internal();
   }
 }
 
@@ -93,20 +99,21 @@ export async function handleKeyRevocation(
 ): Promise<Response> {
   try {
     if (!env.DATABASE_URL) {
-      return createErrorResponse('INTERNAL_ERROR', 'An unexpected error occurred', 500);
+      throw Errors.internal();
     }
 
     const db = createDatabase(env.DATABASE_URL);
     const result = await revokeApiKey(db, keyId, authContext.userId);
 
     if (!result.success) {
-      const errorMap = {
-        KEY_NOT_FOUND: { code: 'KEY_NOT_FOUND' as const, message: 'API key not found', status: 404 },
-        NOT_AUTHORIZED: { code: 'FORBIDDEN' as const, message: 'Not authorized to revoke this key', status: 403 },
-        ALREADY_REVOKED: { code: 'ALREADY_REVOKED' as const, message: 'Key is already revoked', status: 400 },
-      };
-      const err = errorMap[result.error];
-      return createErrorResponse(err.code, err.message, err.status);
+      switch (result.error) {
+        case 'KEY_NOT_FOUND':
+          throw Errors.keyNotFound();
+        case 'NOT_AUTHORIZED':
+          throw Errors.forbidden();
+        case 'ALREADY_REVOKED':
+          throw Errors.alreadyRevoked();
+      }
     }
 
     return new Response(
@@ -120,7 +127,10 @@ export async function handleKeyRevocation(
       },
     );
   } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
     console.error('Key revocation error:', error);
-    return createErrorResponse('INTERNAL_ERROR', 'An unexpected error occurred', 500);
+    throw Errors.internal();
   }
 }

--- a/src/handlers/signup.ts
+++ b/src/handlers/signup.ts
@@ -1,7 +1,6 @@
 import { createDatabase } from '../db';
 import { createUser } from '../services/users';
-import { createErrorResponse } from '../types/errors';
-import { ValidationError, DuplicateError } from '../types/errors';
+import { Errors, ApiError, ValidationError, DuplicateError } from '../types/errors';
 import type { Env } from '../types';
 import type { SignupResponse } from '../types/users';
 
@@ -17,11 +16,11 @@ export async function handleSignup(request: Request, env: Env): Promise<Response
     const body = (await request.json()) as { email?: unknown };
 
     if (!body.email || typeof body.email !== 'string') {
-      return createErrorResponse('INVALID_REQUEST', 'Email is required', 400);
+      throw Errors.invalidRequest('Email is required');
     }
 
     if (!env.DATABASE_URL) {
-      return createErrorResponse('INTERNAL_ERROR', 'An unexpected error occurred', 500);
+      throw Errors.internal();
     }
 
     const db = createDatabase(env.DATABASE_URL);
@@ -47,16 +46,19 @@ export async function handleSignup(request: Request, env: Env): Promise<Response
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
     if (error instanceof ValidationError) {
-      return createErrorResponse('INVALID_REQUEST', error.message, 400);
+      throw Errors.invalidRequest(error.message);
     }
     if (error instanceof DuplicateError) {
-      return createErrorResponse('DUPLICATE_EMAIL', error.message, 409);
+      throw Errors.duplicateEmail();
     }
     if (error instanceof SyntaxError) {
-      return createErrorResponse('INVALID_REQUEST', 'Invalid JSON body', 400);
+      throw Errors.invalidRequest('Invalid JSON body');
     }
     console.error('Signup error:', error);
-    return createErrorResponse('INTERNAL_ERROR', 'An unexpected error occurred', 500);
+    throw Errors.internal();
   }
 }

--- a/src/handlers/stargazers.ts
+++ b/src/handlers/stargazers.ts
@@ -1,5 +1,5 @@
 import { validateRepoIdentifier } from '../utils/validation';
-import { createErrorResponse, createGitHubRateLimitResponse } from '../types/errors';
+import { ApiError, Errors } from '../types/errors';
 import { getStargazers, StargazerError } from '../services/stargazers';
 import { RateLimitError } from '../utils/rateLimit';
 import { parsePaginationParams } from '../utils/pagination';
@@ -27,7 +27,7 @@ export async function handleStargazers(
     formatParams = parseFormatParam(url);
   } catch (error) {
     if (error instanceof InvalidFormatError) {
-      return createErrorResponse('INVALID_FORMAT', error.message, 400);
+      throw Errors.invalidFormat(error.message);
     }
     throw error;
   }
@@ -36,7 +36,7 @@ export async function handleStargazers(
 
   const validation = validateRepoIdentifier(repo);
   if (!validation.valid) {
-    return createErrorResponse('INVALID_REPO', validation.error!, 400);
+    throw Errors.invalidRepo(validation.error!);
   }
 
   const trimmed = repo!.trim();
@@ -45,10 +45,7 @@ export async function handleStargazers(
   const pagination = parsePaginationParams(url);
 
   if (!env.GITHUB_TOKEN) {
-    return new Response(
-      JSON.stringify({ error: { code: 'SERVER_ERROR', message: 'GitHub token not configured' } }),
-      { status: 500, headers: { 'Content-Type': 'application/json' } },
-    );
+    throw Errors.internal();
   }
 
   const redis = createRedisClient(env);
@@ -82,10 +79,13 @@ export async function handleStargazers(
           case 'csv':
             return buildCsvResponse(cacheResult.data.data, owner, repoName, headers);
           default:
-            return createErrorResponse('INVALID_FORMAT', 'Unknown format', 400);
+            throw Errors.invalidFormat('Unknown format');
         }
       }
     } catch (error) {
+      if (error instanceof ApiError) {
+        throw error;
+      }
       console.warn(
         JSON.stringify({
           level: 'warn',
@@ -112,10 +112,7 @@ export async function handleStargazers(
 
       switch (githubRateCheck.action) {
         case 'reject':
-          return createGitHubRateLimitResponse(
-            githubRateCheck.retryAfter!,
-            githubRateCheck.state!.resetAt,
-          );
+          throw Errors.githubRateLimit(githubRateCheck.retryAfter!, githubRateCheck.state!.resetAt);
 
         case 'proceed':
         case 'queue':
@@ -123,6 +120,9 @@ export async function handleStargazers(
           break;
       }
     } catch (error) {
+      if (error instanceof ApiError) {
+        throw error;
+      }
       console.warn(
         JSON.stringify({
           level: 'warn',
@@ -208,15 +208,23 @@ export async function handleStargazers(
       case 'csv':
         return buildCsvResponse(result.data, owner, repoName, headers);
       default:
-        return createErrorResponse('INVALID_FORMAT', 'Unknown format', 400);
+        throw Errors.invalidFormat('Unknown format');
     }
   } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
     if (error instanceof StargazerError) {
-      const statusCode = error.code === 'REPO_NOT_FOUND' ? 404 : 422;
-      return createErrorResponse(error.code, error.message, statusCode);
+      if (error.code === 'REPO_NOT_FOUND') {
+        throw Errors.repoNotFound(`${owner}/${repoName}`);
+      }
+      throw Errors.privateRepo(`${owner}/${repoName}`);
     }
     if (error instanceof RateLimitError) {
-      return createErrorResponse('GITHUB_RATE_LIMIT', error.message, 429);
+      const retryAfter = Math.ceil(
+        Math.max(0, (error.rateLimitStatus.resetAt.getTime() - Date.now()) / 1000),
+      );
+      throw Errors.githubRateLimit(retryAfter, error.rateLimitStatus.resetAt.toISOString());
     }
     console.error(
       JSON.stringify({
@@ -225,9 +233,6 @@ export async function handleStargazers(
         error: error instanceof Error ? error.message : 'Unknown error',
       }),
     );
-    return new Response(
-      JSON.stringify({ error: { code: 'SERVER_ERROR', message: 'Internal server error' } }),
-      { status: 500, headers: { 'Content-Type': 'application/json' } },
-    );
+    throw Errors.githubUnavailable();
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,8 @@ import { handleSignup } from './handlers/signup';
 import { handleCreateKey, handleKeyRotation, handleKeyRevocation } from './handlers/keys';
 import { authenticateRequest } from './middleware/auth';
 import { applyRateLimit } from './middleware/ratelimit';
-import { createUnauthorizedResponse, createRateLimitedResponse } from './types/errors';
+import { withErrorHandler } from './middleware/error-handler';
+import { ApiError, ErrorCode, Errors, createRateLimitedResponse } from './types/errors';
 import { withRateLimitHeaders } from './utils/headers';
 import { createRedisClient } from './services/redis';
 import { Env } from './types';
@@ -12,61 +13,57 @@ import type { RateLimitInfo } from './types/ratelimit';
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    const url = new URL(request.url);
+    return withErrorHandler(async (req, e) => {
+      const url = new URL(req.url);
 
-    if (url.pathname === '/health' && request.method === 'GET') {
-      return handleHealth(env);
-    }
-
-    if (url.pathname === '/api/v1/signup') {
-      return handleSignup(request, env);
-    }
-
-    if (url.pathname.startsWith('/api/v1/')) {
-      const authResult = await authenticateRequest(request, env);
-      if (!authResult.success) {
-        return createUnauthorizedResponse();
+      if (url.pathname === '/health' && req.method === 'GET') {
+        return handleHealth(e);
       }
 
-      let rateLimitInfo: RateLimitInfo | undefined;
-      const redis = createRedisClient(env);
-      if (redis) {
-        const rateLimitResult = await applyRateLimit(redis, authResult.context);
-        rateLimitInfo = rateLimitResult.info;
-        if (!rateLimitResult.allowed) {
-          return createRateLimitedResponse(rateLimitResult.retryAfter!, rateLimitResult.info);
+      if (url.pathname === '/api/v1/signup') {
+        return handleSignup(req, e);
+      }
+
+      if (url.pathname.startsWith('/api/v1/')) {
+        const authResult = await authenticateRequest(req, e);
+        if (!authResult.success) {
+          throw Errors.unauthorized();
         }
-      }
 
-      let response: Response;
+        let rateLimitInfo: RateLimitInfo | undefined;
+        const redis = createRedisClient(e);
+        if (redis) {
+          const rateLimitResult = await applyRateLimit(redis, authResult.context);
+          rateLimitInfo = rateLimitResult.info;
+          if (!rateLimitResult.allowed) {
+            return createRateLimitedResponse(rateLimitResult.retryAfter!, rateLimitResult.info);
+          }
+        }
 
-      if (url.pathname === '/api/v1/stargazers' && request.method === 'GET') {
-        response = await handleStargazers(request, env, authResult.context);
-      } else if (url.pathname === '/api/v1/keys' && request.method === 'POST') {
-        response = await handleCreateKey(request, env, authResult.context);
-      } else if (url.pathname === '/api/v1/keys/rotate' && request.method === 'POST') {
-        response = await handleKeyRotation(request, env, authResult.context);
-      } else {
-        const keyRevokeMatch = url.pathname.match(/^\/api\/v1\/keys\/([a-f0-9-]+)$/);
-        if (keyRevokeMatch && request.method === 'DELETE') {
-          response = await handleKeyRevocation(request, env, authResult.context, keyRevokeMatch[1]);
+        let response: Response;
+
+        if (url.pathname === '/api/v1/stargazers' && req.method === 'GET') {
+          response = await handleStargazers(req, e, authResult.context);
+        } else if (url.pathname === '/api/v1/keys' && req.method === 'POST') {
+          response = await handleCreateKey(req, e, authResult.context);
+        } else if (url.pathname === '/api/v1/keys/rotate' && req.method === 'POST') {
+          response = await handleKeyRotation(req, e, authResult.context);
         } else {
-          response = new Response(JSON.stringify({ error: 'Not Found' }), {
-            status: 404,
-            headers: { 'Content-Type': 'application/json' },
-          });
+          const keyRevokeMatch = url.pathname.match(/^\/api\/v1\/keys\/([a-f0-9-]+)$/);
+          if (keyRevokeMatch && req.method === 'DELETE') {
+            response = await handleKeyRevocation(req, e, authResult.context, keyRevokeMatch[1]);
+          } else {
+            throw new ApiError(ErrorCode.INVALID_REQUEST, 'Not Found', undefined);
+          }
         }
+
+        if (rateLimitInfo) {
+          return withRateLimitHeaders(response, rateLimitInfo);
+        }
+        return response;
       }
 
-      if (rateLimitInfo) {
-        return withRateLimitHeaders(response, rateLimitInfo);
-      }
-      return response;
-    }
-
-    return new Response(JSON.stringify({ error: 'Not Found' }), {
-      status: 404,
-      headers: { 'Content-Type': 'application/json' },
-    });
+      throw new ApiError(ErrorCode.INVALID_REQUEST, 'Not Found', undefined);
+    })(request, env);
   },
 } satisfies ExportedHandler<Env>;

--- a/src/middleware/error-handler.test.ts
+++ b/src/middleware/error-handler.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from 'vitest';
+import { withErrorHandler } from './error-handler';
+import { Errors } from '../types/errors';
+import type { Env } from '../types';
+
+function makeRequest(path = '/test'): Request {
+  return new Request(`https://example.com${path}`);
+}
+
+const mockEnv = {} as Env;
+
+describe('withErrorHandler', () => {
+  it('passes through successful responses', async () => {
+    const handler = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+    const wrapped = withErrorHandler(handler);
+    const response = await wrapped(makeRequest(), mockEnv);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('ok');
+  });
+
+  it('catches ApiError and returns standardized response', async () => {
+    const handler = vi.fn().mockRejectedValue(Errors.unauthorized());
+    const wrapped = withErrorHandler(handler);
+    const response = await wrapped(makeRequest(), mockEnv);
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+    expect(response.headers.get('WWW-Authenticate')).toBe('Bearer');
+
+    const body = await response.json();
+    expect(body).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        message: expect.any(String),
+        documentation_url: expect.any(String),
+      },
+    });
+  });
+
+  it('catches ApiError with retryAfter and includes header', async () => {
+    const handler = vi.fn().mockRejectedValue(Errors.rateLimited(120));
+    const wrapped = withErrorHandler(handler);
+    const response = await wrapped(makeRequest(), mockEnv);
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get('Retry-After')).toBe('120');
+  });
+
+  it('converts unknown Error to INTERNAL_ERROR', async () => {
+    const handler = vi.fn().mockRejectedValue(new Error('something broke'));
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapped = withErrorHandler(handler);
+    const response = await wrapped(makeRequest(), mockEnv);
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+    expect(body.error.message).toBe('An unexpected error occurred.');
+    // Should not expose the internal error message
+    expect(body.error.message).not.toContain('something broke');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('converts thrown string to INTERNAL_ERROR', async () => {
+    const handler = vi.fn().mockRejectedValue('raw string error');
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapped = withErrorHandler(handler);
+    const response = await wrapped(makeRequest(), mockEnv);
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('converts null/undefined thrown to INTERNAL_ERROR', async () => {
+    const handler = vi.fn().mockRejectedValue(null);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapped = withErrorHandler(handler);
+    const response = await wrapped(makeRequest(), mockEnv);
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('logs full error details server-side', async () => {
+    const internalError = new Error('database connection failed');
+    const handler = vi.fn().mockRejectedValue(internalError);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapped = withErrorHandler(handler);
+    await wrapped(makeRequest(), mockEnv);
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('database connection failed'));
+
+    consoleSpy.mockRestore();
+  });
+
+  it('never exposes stack traces in response body', async () => {
+    const error = new Error('secret internal error');
+    error.stack = 'Error: secret\n    at /src/secret/path.ts:42:10';
+    const handler = vi.fn().mockRejectedValue(error);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const wrapped = withErrorHandler(handler);
+    const response = await wrapped(makeRequest(), mockEnv);
+
+    const text = await response.text();
+    expect(text).not.toContain('stack');
+    expect(text).not.toContain('/src/secret/path.ts');
+    expect(text).not.toContain('secret internal error');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('all error responses have Content-Type: application/json', async () => {
+    const errors = [
+      Errors.invalidRepo(),
+      Errors.unauthorized(),
+      Errors.rateLimited(60),
+      Errors.repoNotFound('a/b'),
+      Errors.privateRepo('a/b'),
+      Errors.githubRateLimit(300),
+      Errors.internal(),
+      Errors.githubUnavailable(),
+    ];
+
+    for (const error of errors) {
+      const handler = vi.fn().mockRejectedValue(error);
+      const wrapped = withErrorHandler(handler);
+      const response = await wrapped(makeRequest(), mockEnv);
+      expect(response.headers.get('Content-Type')).toBe('application/json');
+    }
+  });
+});

--- a/src/middleware/error-handler.ts
+++ b/src/middleware/error-handler.ts
@@ -1,0 +1,40 @@
+import { ApiError, Errors } from '../types/errors';
+import type { Env } from '../types';
+
+export type RequestHandler = (
+  request: Request,
+  env: Env,
+  ctx?: ExecutionContext,
+) => Promise<Response>;
+
+export function withErrorHandler(handler: RequestHandler): RequestHandler {
+  return async (request, env, ctx) => {
+    try {
+      return await handler(request, env, ctx);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        console.error(
+          JSON.stringify({
+            level: 'error',
+            message: 'API Error',
+            code: error.code,
+            statusCode: error.statusCode,
+          }),
+        );
+        return error.toResponse();
+      }
+
+      console.error(
+        JSON.stringify({
+          level: 'error',
+          message: 'Unhandled error',
+          name: error instanceof Error ? error.name : 'Unknown',
+          detail: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+        }),
+      );
+
+      return Errors.internal().toResponse();
+    }
+  };
+}

--- a/src/types/errors.test.ts
+++ b/src/types/errors.test.ts
@@ -1,14 +1,228 @@
 import { describe, it, expect } from 'vitest';
 import {
+  ApiError,
+  ErrorCode,
+  ErrorStatusMap,
+  ErrorMessages,
+  Errors,
   createRateLimitedResponse,
   createErrorResponse,
   createGitHubRateLimitResponse,
+  createUnauthorizedResponse,
 } from './errors';
 import type { RateLimitInfo } from './ratelimit';
 
 const defaultInfo: RateLimitInfo = { remaining: 0, limit: 100, resetAt: 1710864000 };
 
-describe('createRateLimitedResponse', () => {
+describe('ApiError', () => {
+  it('sets code, statusCode, and message from ErrorCode', () => {
+    const error = new ApiError(ErrorCode.INVALID_REPO);
+    expect(error.code).toBe('INVALID_REPO');
+    expect(error.statusCode).toBe(400);
+    expect(error.message).toBe(ErrorMessages.INVALID_REPO);
+    expect(error.name).toBe('ApiError');
+  });
+
+  it('allows custom message override', () => {
+    const error = new ApiError(ErrorCode.INVALID_REPO, 'Custom message');
+    expect(error.message).toBe('Custom message');
+    expect(error.code).toBe('INVALID_REPO');
+  });
+
+  it('stores retryAfter and resetAt', () => {
+    const error = new ApiError(ErrorCode.GITHUB_RATE_LIMIT, undefined, 600, '2026-03-19T12:00:00Z');
+    expect(error.retryAfter).toBe(600);
+    expect(error.resetAt).toBe('2026-03-19T12:00:00Z');
+  });
+
+  it('extends Error', () => {
+    const error = new ApiError(ErrorCode.INTERNAL_ERROR);
+    expect(error).toBeInstanceOf(Error);
+  });
+});
+
+describe('ApiError.toResponseBody', () => {
+  it('returns standardized error body format', () => {
+    const error = new ApiError(ErrorCode.REPO_NOT_FOUND);
+    const body = error.toResponseBody();
+
+    expect(body).toEqual({
+      error: {
+        code: 'REPO_NOT_FOUND',
+        message: ErrorMessages.REPO_NOT_FOUND,
+        documentation_url: expect.stringContaining('error-codes'),
+      },
+    });
+  });
+
+  it('includes retry_after for rate limit errors', () => {
+    const error = new ApiError(ErrorCode.RATE_LIMITED, undefined, 60);
+    const body = error.toResponseBody();
+
+    expect(body.error.retry_after).toBe(60);
+  });
+
+  it('includes reset_at for GitHub rate limit errors', () => {
+    const error = new ApiError(ErrorCode.GITHUB_RATE_LIMIT, undefined, 600, '2026-03-19T12:00:00Z');
+    const body = error.toResponseBody();
+
+    expect(body.error.retry_after).toBe(600);
+    expect(body.error.reset_at).toBe('2026-03-19T12:00:00Z');
+  });
+
+  it('omits retry_after when not set', () => {
+    const error = new ApiError(ErrorCode.INTERNAL_ERROR);
+    const body = error.toResponseBody();
+
+    expect(body.error.retry_after).toBeUndefined();
+  });
+});
+
+describe('ApiError.toResponse', () => {
+  it('returns correct HTTP status code', async () => {
+    const error = new ApiError(ErrorCode.REPO_NOT_FOUND);
+    const response = error.toResponse();
+
+    expect(response.status).toBe(404);
+  });
+
+  it('sets Content-Type to application/json', () => {
+    const error = new ApiError(ErrorCode.INTERNAL_ERROR);
+    const response = error.toResponse();
+
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+  });
+
+  it('includes Retry-After header for rate limit errors', () => {
+    const error = new ApiError(ErrorCode.GITHUB_RATE_LIMIT, undefined, 300);
+    const response = error.toResponse();
+
+    expect(response.headers.get('Retry-After')).toBe('300');
+  });
+
+  it('does not include Retry-After for non-rate-limit errors', () => {
+    const error = new ApiError(ErrorCode.INVALID_REPO);
+    const response = error.toResponse();
+
+    expect(response.headers.get('Retry-After')).toBeNull();
+  });
+
+  it('includes WWW-Authenticate for UNAUTHORIZED errors', () => {
+    const error = new ApiError(ErrorCode.UNAUTHORIZED);
+    const response = error.toResponse();
+
+    expect(response.headers.get('WWW-Authenticate')).toBe('Bearer');
+  });
+
+  it('returns valid JSON body', async () => {
+    const error = new ApiError(ErrorCode.INVALID_REPO, 'Bad repo format');
+    const response = error.toResponse();
+    const body = await response.json();
+
+    expect(body).toEqual({
+      error: {
+        code: 'INVALID_REPO',
+        message: 'Bad repo format',
+        documentation_url: expect.stringContaining('error-codes'),
+      },
+    });
+  });
+});
+
+describe('ErrorStatusMap', () => {
+  it.each([
+    ['INVALID_REPO', 400],
+    ['UNAUTHORIZED', 401],
+    ['RATE_LIMITED', 403],
+    ['REPO_NOT_FOUND', 404],
+    ['PRIVATE_REPO', 422],
+    ['GITHUB_RATE_LIMIT', 429],
+    ['INTERNAL_ERROR', 500],
+    ['GITHUB_UNAVAILABLE', 503],
+  ] as const)('maps %s to status %d', (code, expectedStatus) => {
+    expect(ErrorStatusMap[code]).toBe(expectedStatus);
+  });
+});
+
+describe('Errors factory', () => {
+  it('creates invalidRepo error', () => {
+    const error = Errors.invalidRepo();
+    expect(error.code).toBe('INVALID_REPO');
+    expect(error.statusCode).toBe(400);
+  });
+
+  it('creates invalidRepo with custom detail', () => {
+    const error = Errors.invalidRepo('Missing repo param');
+    expect(error.message).toBe('Missing repo param');
+  });
+
+  it('creates unauthorized error with 401 and WWW-Authenticate', () => {
+    const error = Errors.unauthorized();
+    expect(error.code).toBe('UNAUTHORIZED');
+    expect(error.statusCode).toBe(401);
+    const response = error.toResponse();
+    expect(response.headers.get('WWW-Authenticate')).toBe('Bearer');
+  });
+
+  it('creates rateLimited error with retryAfter', () => {
+    const error = Errors.rateLimited(120);
+    expect(error.code).toBe('RATE_LIMITED');
+    expect(error.statusCode).toBe(403);
+    expect(error.retryAfter).toBe(120);
+  });
+
+  it('creates repoNotFound error', () => {
+    const error = Errors.repoNotFound('owner/repo');
+    expect(error.code).toBe('REPO_NOT_FOUND');
+    expect(error.statusCode).toBe(404);
+    expect(error.message).toContain('owner/repo');
+  });
+
+  it('creates privateRepo error', () => {
+    const error = Errors.privateRepo('owner/repo');
+    expect(error.code).toBe('PRIVATE_REPO');
+    expect(error.statusCode).toBe(422);
+    expect(error.message).toContain('owner/repo');
+  });
+
+  it('creates githubRateLimit error with retryAfter and resetAt', () => {
+    const error = Errors.githubRateLimit(600, '2026-03-19T12:00:00Z');
+    expect(error.code).toBe('GITHUB_RATE_LIMIT');
+    expect(error.statusCode).toBe(429);
+    expect(error.retryAfter).toBe(600);
+    expect(error.resetAt).toBe('2026-03-19T12:00:00Z');
+  });
+
+  it('creates internal error', () => {
+    const error = Errors.internal();
+    expect(error.code).toBe('INTERNAL_ERROR');
+    expect(error.statusCode).toBe(500);
+  });
+
+  it('creates githubUnavailable error', () => {
+    const error = Errors.githubUnavailable();
+    expect(error.code).toBe('GITHUB_UNAVAILABLE');
+    expect(error.statusCode).toBe(503);
+  });
+});
+
+describe('Error sanitization', () => {
+  it('internal error does not expose details', () => {
+    const error = Errors.internal();
+    const body = error.toResponseBody();
+
+    expect(body.error.message).toBe('An unexpected error occurred.');
+    expect(JSON.stringify(body)).not.toContain('stack');
+    expect(JSON.stringify(body)).not.toContain('trace');
+  });
+
+  it('unauthorized error does not reveal key existence', () => {
+    const error = Errors.unauthorized();
+    expect(error.message).toBe('Missing or invalid API key');
+  });
+});
+
+describe('createRateLimitedResponse (legacy)', () => {
   it('returns 403 status', async () => {
     const response = createRateLimitedResponse(36, defaultInfo);
     expect(response.status).toBe(403);
@@ -52,7 +266,7 @@ describe('createRateLimitedResponse', () => {
   });
 });
 
-describe('createErrorResponse with rate limit info', () => {
+describe('createErrorResponse (legacy) with rate limit info', () => {
   const info: RateLimitInfo = { remaining: 42, limit: 100, resetAt: 1710864000 };
 
   it('includes rate limit headers when info is provided', () => {
@@ -71,9 +285,21 @@ describe('createErrorResponse with rate limit info', () => {
     const response = createErrorResponse('INVALID_REPO', 'Bad repo', 400, info);
     expect(response.headers.get('Retry-After')).toBeNull();
   });
+
+  it('produces standardized error body', async () => {
+    const response = createErrorResponse('INVALID_REPO', 'Bad repo', 400);
+    const body = await response.json();
+    expect(body).toEqual({
+      error: {
+        code: 'INVALID_REPO',
+        message: 'Bad repo',
+        documentation_url: expect.stringContaining('error-codes'),
+      },
+    });
+  });
 });
 
-describe('createGitHubRateLimitResponse', () => {
+describe('createGitHubRateLimitResponse (legacy)', () => {
   const resetAt = '2026-03-19T12:00:00Z';
 
   it('returns 429 status', () => {
@@ -110,5 +336,29 @@ describe('createGitHubRateLimitResponse', () => {
     const body = (await response.json()) as { error: { retry_after: number; reset_at: string } };
     expect(body.error.retry_after).toBe(1800);
     expect(body.error.reset_at).toBe(resetAt);
+  });
+});
+
+describe('createUnauthorizedResponse (legacy)', () => {
+  it('returns 401 status', () => {
+    const response = createUnauthorizedResponse();
+    expect(response.status).toBe(401);
+  });
+
+  it('includes WWW-Authenticate header', () => {
+    const response = createUnauthorizedResponse();
+    expect(response.headers.get('WWW-Authenticate')).toBe('Bearer');
+  });
+
+  it('returns standardized error body', async () => {
+    const response = createUnauthorizedResponse();
+    const body = await response.json();
+    expect(body).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        message: 'Missing or invalid API key',
+        documentation_url: expect.any(String),
+      },
+    });
   });
 });

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,21 +1,128 @@
 import type { RateLimitInfo } from './ratelimit';
 import { createRateLimitHeaders, createRateLimitedHeaders } from '../utils/headers';
 
-export type ErrorCode =
-  | 'INVALID_REPO'
-  | 'REPO_NOT_FOUND'
-  | 'PRIVATE_REPO'
-  | 'GITHUB_RATE_LIMIT'
-  | 'INVALID_FORMAT'
-  | 'FORMAT_NOT_IMPLEMENTED'
-  | 'UNAUTHORIZED'
-  | 'INVALID_REQUEST'
-  | 'DUPLICATE_EMAIL'
-  | 'KEY_NOT_FOUND'
-  | 'FORBIDDEN'
-  | 'ALREADY_REVOKED'
-  | 'RATE_LIMITED'
-  | 'INTERNAL_ERROR';
+export const ErrorCode = {
+  INVALID_REPO: 'INVALID_REPO',
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  RATE_LIMITED: 'RATE_LIMITED',
+  REPO_NOT_FOUND: 'REPO_NOT_FOUND',
+  PRIVATE_REPO: 'PRIVATE_REPO',
+  GITHUB_RATE_LIMIT: 'GITHUB_RATE_LIMIT',
+  INTERNAL_ERROR: 'INTERNAL_ERROR',
+  GITHUB_UNAVAILABLE: 'GITHUB_UNAVAILABLE',
+  INVALID_FORMAT: 'INVALID_FORMAT',
+  FORMAT_NOT_IMPLEMENTED: 'FORMAT_NOT_IMPLEMENTED',
+  INVALID_REQUEST: 'INVALID_REQUEST',
+  DUPLICATE_EMAIL: 'DUPLICATE_EMAIL',
+  KEY_NOT_FOUND: 'KEY_NOT_FOUND',
+  FORBIDDEN: 'FORBIDDEN',
+  ALREADY_REVOKED: 'ALREADY_REVOKED',
+} as const;
+
+export type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+export const ErrorStatusMap: Record<ErrorCodeType, number> = {
+  INVALID_REPO: 400,
+  UNAUTHORIZED: 401,
+  RATE_LIMITED: 403,
+  REPO_NOT_FOUND: 404,
+  PRIVATE_REPO: 422,
+  GITHUB_RATE_LIMIT: 429,
+  INTERNAL_ERROR: 500,
+  GITHUB_UNAVAILABLE: 503,
+  INVALID_FORMAT: 400,
+  FORMAT_NOT_IMPLEMENTED: 400,
+  INVALID_REQUEST: 400,
+  DUPLICATE_EMAIL: 409,
+  KEY_NOT_FOUND: 404,
+  FORBIDDEN: 403,
+  ALREADY_REVOKED: 409,
+};
+
+export const ErrorMessages: Record<ErrorCodeType, string> = {
+  INVALID_REPO: 'Repository format invalid. Expected format: owner/repo',
+  UNAUTHORIZED: 'Missing or invalid API key',
+  RATE_LIMITED: 'Rate limit exceeded. Please retry after the specified time.',
+  REPO_NOT_FOUND: 'GitHub repository does not exist.',
+  PRIVATE_REPO: 'Cannot access stargazers of a private repository.',
+  GITHUB_RATE_LIMIT: 'GitHub API rate limit exhausted. Please retry after the specified time.',
+  INTERNAL_ERROR: 'An unexpected error occurred.',
+  GITHUB_UNAVAILABLE: 'GitHub API is temporarily unavailable.',
+  INVALID_FORMAT: 'Invalid response format requested.',
+  FORMAT_NOT_IMPLEMENTED: 'Requested format is not implemented.',
+  INVALID_REQUEST: 'Invalid request.',
+  DUPLICATE_EMAIL: 'Email already registered.',
+  KEY_NOT_FOUND: 'API key not found.',
+  FORBIDDEN: 'Access denied.',
+  ALREADY_REVOKED: 'API key is already revoked.',
+};
+
+const DOCUMENTATION_BASE_URL = 'https://github.com/backant/github-stargazers-scraper#error-codes';
+
+export interface ErrorResponseBody {
+  error: {
+    code: ErrorCodeType;
+    message: string;
+    documentation_url: string;
+    retry_after?: number;
+    reset_at?: string;
+  };
+}
+
+export class ApiError extends Error {
+  public readonly code: ErrorCodeType;
+  public readonly statusCode: number;
+  public readonly retryAfter?: number;
+  public readonly resetAt?: string;
+
+  constructor(code: ErrorCodeType, message?: string, retryAfter?: number, resetAt?: string) {
+    super(message || ErrorMessages[code]);
+    this.code = code;
+    this.statusCode = ErrorStatusMap[code];
+    this.retryAfter = retryAfter;
+    this.resetAt = resetAt;
+    this.name = 'ApiError';
+  }
+
+  toResponseBody(): ErrorResponseBody {
+    const body: ErrorResponseBody = {
+      error: {
+        code: this.code,
+        message: this.message,
+        documentation_url: DOCUMENTATION_BASE_URL,
+      },
+    };
+
+    if (this.retryAfter !== undefined) {
+      body.error.retry_after = this.retryAfter;
+    }
+
+    if (this.resetAt !== undefined) {
+      body.error.reset_at = this.resetAt;
+    }
+
+    return body;
+  }
+
+  toResponse(): Response {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    if (this.retryAfter !== undefined) {
+      headers['Retry-After'] = String(this.retryAfter);
+    }
+
+    if (this.code === 'UNAUTHORIZED') {
+      headers['WWW-Authenticate'] = 'Bearer';
+    }
+
+    return new Response(JSON.stringify(this.toResponseBody()), {
+      status: this.statusCode,
+      headers,
+    });
+  }
+}
 
 export class ValidationError extends Error {
   constructor(message: string) {
@@ -31,29 +138,66 @@ export class DuplicateError extends Error {
   }
 }
 
+// Convenience factory functions
+export const Errors = {
+  invalidRepo: (detail?: string) =>
+    new ApiError(ErrorCode.INVALID_REPO, detail || ErrorMessages.INVALID_REPO),
+
+  unauthorized: () => new ApiError(ErrorCode.UNAUTHORIZED),
+
+  rateLimited: (retryAfter: number) => new ApiError(ErrorCode.RATE_LIMITED, undefined, retryAfter),
+
+  repoNotFound: (repo?: string) =>
+    new ApiError(
+      ErrorCode.REPO_NOT_FOUND,
+      repo ? `Repository '${repo}' not found on GitHub.` : undefined,
+    ),
+
+  privateRepo: (repo?: string) =>
+    new ApiError(
+      ErrorCode.PRIVATE_REPO,
+      repo ? `Repository '${repo}' is private and cannot be accessed.` : undefined,
+    ),
+
+  githubRateLimit: (retryAfter: number, resetAt?: string) =>
+    new ApiError(ErrorCode.GITHUB_RATE_LIMIT, undefined, retryAfter, resetAt),
+
+  internal: () => new ApiError(ErrorCode.INTERNAL_ERROR),
+
+  githubUnavailable: () => new ApiError(ErrorCode.GITHUB_UNAVAILABLE),
+
+  invalidFormat: (detail?: string) =>
+    new ApiError(ErrorCode.INVALID_FORMAT, detail || ErrorMessages.INVALID_FORMAT),
+
+  invalidRequest: (detail?: string) =>
+    new ApiError(ErrorCode.INVALID_REQUEST, detail || ErrorMessages.INVALID_REQUEST),
+
+  duplicateEmail: () => new ApiError(ErrorCode.DUPLICATE_EMAIL),
+
+  keyNotFound: () => new ApiError(ErrorCode.KEY_NOT_FOUND),
+
+  forbidden: () => new ApiError(ErrorCode.FORBIDDEN),
+
+  alreadyRevoked: () => new ApiError(ErrorCode.ALREADY_REVOKED),
+};
+
+// Legacy helpers preserved for backward compatibility during migration
 export interface ErrorResponse {
   error: {
-    code: ErrorCode;
+    code: ErrorCodeType;
     message: string;
     documentation_url: string;
   };
 }
 
-const DOCUMENTATION_BASE_URL = 'https://github.com/backant/github-stargazers-scraper#error-codes';
-
 export function createErrorResponse(
-  code: ErrorCode,
+  code: ErrorCodeType,
   message: string,
   statusCode: number,
   rateLimitInfo?: RateLimitInfo,
 ): Response {
-  const body: ErrorResponse = {
-    error: {
-      code,
-      message,
-      documentation_url: DOCUMENTATION_BASE_URL,
-    },
-  };
+  const apiError = new ApiError(code, message);
+  const body = apiError.toResponseBody();
 
   const rateLimitHeaders = rateLimitInfo ? createRateLimitHeaders(rateLimitInfo) : {};
 
@@ -64,14 +208,8 @@ export function createErrorResponse(
 }
 
 export function createRateLimitedResponse(retryAfter: number, info: RateLimitInfo): Response {
-  const body = {
-    error: {
-      code: 'RATE_LIMITED' as ErrorCode,
-      message: 'Rate limit exceeded. Please retry after the specified time.',
-      retry_after: retryAfter,
-      documentation_url: DOCUMENTATION_BASE_URL,
-    },
-  };
+  const apiError = new ApiError(ErrorCode.RATE_LIMITED, undefined, retryAfter);
+  const body = apiError.toResponseBody();
 
   const headers = createRateLimitedHeaders(info, retryAfter);
 
@@ -85,39 +223,10 @@ export function createRateLimitedResponse(retryAfter: number, info: RateLimitInf
 }
 
 export function createGitHubRateLimitResponse(retryAfter: number, resetAt: string): Response {
-  const body = {
-    error: {
-      code: 'GITHUB_RATE_LIMIT' as ErrorCode,
-      message: 'GitHub API rate limit exhausted. Please retry after the specified time.',
-      retry_after: retryAfter,
-      reset_at: resetAt,
-      documentation_url: DOCUMENTATION_BASE_URL,
-    },
-  };
-
-  return new Response(JSON.stringify(body), {
-    status: 429,
-    headers: {
-      'Content-Type': 'application/json',
-      'Retry-After': retryAfter.toString(),
-    },
-  });
+  const apiError = new ApiError(ErrorCode.GITHUB_RATE_LIMIT, undefined, retryAfter, resetAt);
+  return apiError.toResponse();
 }
 
 export function createUnauthorizedResponse(): Response {
-  const body: ErrorResponse = {
-    error: {
-      code: 'UNAUTHORIZED',
-      message: 'Missing or invalid API key',
-      documentation_url: DOCUMENTATION_BASE_URL,
-    },
-  };
-
-  return new Response(JSON.stringify(body), {
-    status: 401,
-    headers: {
-      'Content-Type': 'application/json',
-      'WWW-Authenticate': 'Bearer',
-    },
-  });
+  return Errors.unauthorized().toResponse();
 }


### PR DESCRIPTION
## Summary

- Introduces `ApiError` class with standardized error response format (`code`, `message`, `documentation_url`, optional `retry_after`/`reset_at`)
- Adds `ErrorCode` constants, `ErrorStatusMap`, and `ErrorMessages` for all error types (INVALID_REPO, UNAUTHORIZED, RATE_LIMITED, REPO_NOT_FOUND, PRIVATE_REPO, GITHUB_RATE_LIMIT, INTERNAL_ERROR, GITHUB_UNAVAILABLE, etc.)
- Adds `Errors` factory with convenience methods for creating typed errors
- Adds `withErrorHandler` middleware that wraps the entire request flow, catching `ApiError` instances and converting unknown errors to safe `INTERNAL_ERROR` responses
- Updates all handlers (stargazers, keys, signup) and index.ts to throw `ApiError` instead of returning ad-hoc error responses
- Ensures rate limit errors include `Retry-After` header and `retry_after` body field
- Ensures internal errors never expose stack traces or sensitive details

## Test plan

- [x] All 185 existing + new tests pass
- [x] TypeScript strict mode typecheck passes
- [x] ESLint passes with no warnings
- [x] Prettier format check passes
- [x] Unit tests cover: ApiError creation, response body format, HTTP status mapping, retry_after inclusion, documentation URL, error sanitization
- [x] Integration tests cover: error handler catching ApiError, catching unknown Error/string/null, server-side logging, no sensitive data leakage

Closes #109